### PR TITLE
fix Trying to get property of non-object in some cases

### DIFF
--- a/ProcessCustomUploadNames.module
+++ b/ProcessCustomUploadNames.module
@@ -175,7 +175,9 @@ class ProcessCustomUploadNames extends WireData implements Module, ConfigurableM
                 if($field->type instanceof FieldtypeFile) {
                     if(count($editedPage->{$field->name})) {
                         foreach($editedPage->{$field->name} as $file) {
-                            $files[$file->name] = $field->id; // add filename with respective fieldid to array
+                            if (is_object($file) && $file->id && $file->name){
+                                $files[$file->name] = $field->id; // add filename with respective fieldid to array
+                            }
                         }
                     }
                 }
@@ -184,7 +186,9 @@ class ProcessCustomUploadNames extends WireData implements Module, ConfigurableM
                         if($rf->type instanceof FieldtypeFile) {
                             if(count($editedPage->{$field->name}->{$rf->name})) {
                                 foreach($editedPage->{$field->name}->{$rf->name} as $file) {
-                                    $files[$file->name] = $editedPage->{$field->name}->id.'|'.$field->id; // add filename with respective fieldid to array
+                                    if (is_object($file) && $file->id && $file->name){
+                                        $files[$file->name] = $editedPage->{$field->name}->id.'|'.$field->id; // add filename with respective fieldid to array
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Hi! In some cases, this might be a problem.
For example, I add a file through api with given full path:
$page->of(false);
$page->image = '/root/file/path/image.png';
$page->save();

and the error occurs.
I actually do it in my module and I can't cancel your hook when I really need it. Settings are irrelevant, I still need CustomUploadNames to hook for this field when I edit it in the admin panel.

Thank you for your module!