### PR TITLE
Fix PHP 8 deprecation warnings in inputfield helpers

### DIFF
--- a/ProcessCustomUploadNames.module.php
+++ b/ProcessCustomUploadNames.module.php
@@ -755,7 +755,7 @@ class ProcessCustomUploadNames extends WireData implements Module, ConfigurableM
         exit;
     }
 
-    private function _createInputfieldText($ipName, $ipTitle, $ipValue='', $ipDesc='', $ipOptions='', $ipNotes='', $ipWidth, $ipRequired=false) {
+    private function _createInputfieldText($ipName, $ipTitle, $ipValue='', $ipDesc='', $ipOptions='', $ipNotes='', $ipWidth=100, $ipRequired=false) {
         $field =  $this->wire('modules')->get("InputfieldText");
         $field->name = $ipName;
         $field->label = $ipTitle;
@@ -767,7 +767,7 @@ class ProcessCustomUploadNames extends WireData implements Module, ConfigurableM
         return $field;
     }
 
-    private function _createInputfieldCheckbox($ipName, $ipTitle, $ipValue='', $ipDesc='', $ipOptions='', $ipNotes='', $ipWidth, $ipRequired=false) {
+    private function _createInputfieldCheckbox($ipName, $ipTitle, $ipValue='', $ipDesc='', $ipOptions='', $ipNotes='', $ipWidth=100, $ipRequired=false) {
         $field = $this->wire('modules')->get("InputfieldCheckbox");
         $field->name = $ipName;
         $field->label = $ipTitle;


### PR DESCRIPTION
Gives `$ipWidth` a default value (`100`) in `_createInputfieldText` and `_createInputfieldCheckbox` so it no longer sits after optional parameters as an implicitly-required parameter — the source of PHP 8 deprecation notices.

All 15 call sites pass `$ipWidth` explicitly (always `25`), so the default is never used and behavior is unchanged. `100` mirrors the existing `_createInputfieldAsmSelect($aWidth=100)` convention.

Verified with `php -l`: no syntax errors, no deprecation notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)